### PR TITLE
Add Nutilz Color Shades Generator to Accessibility (a11y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ See design tools plugins [here](https://github.com/LisaDziuba/Awesome-Design-Too
 - [Stark](https://www.getstark.co/) - Empowers you to design with accessibility in mind from conception of brand to fruition of product. Contrast checker, colorblind simulation and color suggestions.
 - [The A11Y Project](https://a11yproject.com/) - A community-driven effort to make web accessibility easier. See [resources](https://a11yproject.com/resources/) section.
 - [InclusiveColors palette creator](https://www.inclusivecolors.com/) - Creates accessible custom Tailwind-style color palettes that pass WCAG contrast checks and can be exported to CSS/Figma/Adobe.
+- [Nutilz Color Shades Generator](https://nutilz.com/color-shades-generator) - Generates a 50-950 tint/shade scale from any hex color and exports it as CSS variables, SCSS, or a Tailwind config.
 
 ### Design tools articles
 


### PR DESCRIPTION
Adds [Nutilz Color Shades Generator](https://nutilz.com/color-shades-generator), a free tool that generates a 50-950 tint/shade scale from a single hex color and exports it as CSS variables, SCSS, or a Tailwind config. Placed next to InclusiveColors in Accessibility (a11y) since it produces the same kind of Tailwind-style shade scale used for design tokens. No signup required, free to use.